### PR TITLE
fix: Correct translation key for "Explorer Under Construction" to "Lo…

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,5 +1,5 @@
 {
-  "Explorer Under Construction": "Explorador en construcción",
+  "Lost Explorer": "Explorador en construcción",
   "Digital Learner": "Aprendiz digital",
   "Chaotic Self-Taught": "Autodidacta caótico",
   "Productive Visionary": "Visionario en acción",


### PR DESCRIPTION
…st Explorer" in English JSON file